### PR TITLE
Simple CMake build scripts and Linux fixes

### DIFF
--- a/BON/bon.h
+++ b/BON/bon.h
@@ -12,6 +12,15 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#if defined(__linux__)
+#  include <endian.h>
+#  if __BYTE_ORDER == __LITTLE_ENDIAN
+#    define __LITTLE_ENDIAN__ 1
+#  elif __BYTE_ORDER == __BIG_ENDIAN
+#    define __BIG_ENDIAN__ 1
+#  endif
+#endif
+
 #if !__LITTLE_ENDIAN__ && !__BIG_ENDIAN__
 #  error "BON lib doesn't work on mixed endian machines!"
 #elif __LITTLE_ENDIAN__ && __BIG_ENDIAN__

--- a/BON/bon_private.h
+++ b/BON/bon_private.h
@@ -9,6 +9,8 @@
 #ifndef BON_bon_private_h
 #define BON_bon_private_h
 
+#include <stdarg.h>
+
 /*
  This is NOT part of the public API.
  Only include this file if you want to poke around the internals of BON!

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,62 @@
+cmake_minimum_required(VERSION 2.8)
+project(BON)
+
+if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+	add_definitions("-std=c99")
+endif()
+
+add_library(BON
+	BON/bon.c
+	BON/bon.h
+	BON/bon_private.h
+	BON/crc32.c
+	BON/crc32.h
+	BON/read.c
+	BON/type.c
+	BON/write.c)
+
+add_library(jansson STATIC
+	jansson/dump.c
+	jansson/error.c
+	jansson/hashtable.c
+	jansson/hashtable.h
+	jansson/jansson_config.h
+	jansson/jansson.h
+	jansson/jansson_private.h
+	jansson/load.c
+	jansson/memory.c
+	jansson/pack_unpack.c
+	jansson/strbuffer.c
+	jansson/strbuffer.h
+	jansson/strconv.c
+	jansson/utf.c
+	jansson/utf.h
+	jansson/value.c)
+
+include_directories(${BON_SOURCE_DIR}/BON)
+include_directories(${BON_SOURCE_DIR}/jansson)
+add_executable(json2bon
+	json2bon/json2bon.c)
+target_link_libraries(json2bon BON jansson)
+
+add_executable(bon2json
+	bon2json/bon2json.c)
+target_link_libraries(bon2json BON jansson)
+
+install(TARGETS
+	BON
+	json2bon
+	bon2json
+	RUNTIME DESTINATION bin
+	LIBRARY DESTINATION lib
+	ARCHIVE DESTINATION lib)
+
+install(FILES
+	BON/bon.h
+	DESTINATION include)
+
+install(FILES
+	BON/BON.1
+	bon2json/bon2json.1
+	json2bon/json2bon.1
+	DESTINATION share/man)


### PR DESCRIPTION
These commits add the standard header needed for va_list and uses Linux's endian.h to define OS X-like endianess defines.

The CMake build is tested on Linux, and should thus probably work on most OSes of that kind.
