### PR TITLE
Put artifacts in bin subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(BON)
 if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 	add_definitions("-std=c99")
 endif()
+SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY bin)
 
 add_library(BON
 	BON/bon.c


### PR DESCRIPTION
As on some platforms, executables share the same name as some source
directories, resulting in name clashes when building.

This commit puts all library and binary artifacts in a bin directory.
