### PR TITLE
Eliminate warnings/errors found by PVS-Studio analyzer

### DIFF
--- a/libbon/bon/bon.c
+++ b/libbon/bon/bon.c
@@ -42,7 +42,9 @@ uint8_t* bon_read_file(bon_size* out_size, const char* path)
 	size_t blocks_read = fread(data, fileSize, 1, fp);
 	if (blocks_read != 1) {
 		fprintf(stderr, "Failed to read file %s\n", path);
-		return NULL ;
+		fclose(fp);
+		free(data);
+		return NULL;
 	}
 	
 	fclose(fp);
@@ -158,7 +160,7 @@ void bon_print_aggr(bon_r_doc* B, const bon_type* aggType, bon_reader* br, FILE*
 		case BON_CTRL_SINT64_BE: {
 			int64_t s64 = br_read_sint64(br, id);
 			fprintf(out, "%"PRIi64, s64);
-		}
+		} break;
 			
 			
 		case BON_CTRL_UINT8:
@@ -305,7 +307,7 @@ void bon_print(bon_r_doc* B, bon_value* v, FILE* out, size_t indent)
 			
 		case BON_VALUE_BLOCK_REF: {
 			fprintf(out, "@%"PRIu64, v->u.blockRefId);
-		}
+		} break;
 			
 		default:
 			fprintf(out, "ERROR");

--- a/libbon/bon/private.h
+++ b/libbon/bon/private.h
@@ -72,9 +72,9 @@ typedef enum {
 } bon_compressed_ranges;
 
 #ifdef DEBUG
-#  define BON_COMPRESS_(start, count, n)  (assert(n < count), (uint8_t)((start) + n))
+#  define BON_COMPRESS_(start, count, n)  (assert((n) < (count)), (uint8_t)((start) + n))
 #else
-#  define BON_COMPRESS_(start, count, n)  (uint8_t)((start) + n)
+#  define BON_COMPRESS_(start, count, n)  (uint8_t)((start) + (n))
 #endif
 
 #define BON_COMPRESS(prefix, n)  BON_COMPRESS_(prefix ## START, prefix ## COUNT, n)
@@ -298,8 +298,8 @@ uint32_t uint32_to_le(uint32_t v);
 //------------------------------------------------------------------------------
 
 // TODO: handle failed allocs
-#define BON_ALLOC_TYPE(n, type)   (type*)malloc(n * sizeof(type))
-#define BON_CALLOC_TYPE(n, type)  (type*)calloc(n, sizeof(type))
+#define BON_ALLOC_TYPE(n, type)   (type*)malloc((n) * sizeof(type))
+#define BON_CALLOC_TYPE(n, type)  (type*)calloc((n), sizeof(type))
 
 #if 0
 // Doubling in size. Only makes about 4% (positive) dfference in speed.

--- a/libbon/bon/read.c
+++ b/libbon/bon/read.c
@@ -1096,7 +1096,7 @@ bon_r_doc* bon_r_open(const uint8_t* data, bon_size nbytes, bon_r_flags flags)
 		strcpy(msg, str);
 		
 		if (br->err_offset) {
-			snprintf(msg + strlen(str), extra, " (around byte %ld)", br->err_offset - data);
+			snprintf(msg + strlen(str), extra, " (around byte %td)", br->err_offset - data);
 		}
 		
 		B->errstr = msg;
@@ -1392,7 +1392,9 @@ bon_bool bw_write_raw(bon_writer* bw, const void* in, size_t n) {
 // Write bytes in reversed order (i.e. reverse endian)
 bon_bool bw_write_raw_reversed(bon_writer* bw, const void* in, size_t n) {
 	if (bw->nbytes >= n) {
-		memcpy(bw->data, in, n);
+		for (size_t i = 0; i < n; ++i) {
+			bw->data[i] = ((uint8_t*)in)[n - i - 1];
+		}
 		bw->data   += n;
 		bw->nbytes -= n;
 		return BON_TRUE;


### PR DESCRIPTION
Hello!
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A list of bugs, found using PVS-Studio analyzer:

- [V524](https://www.viva64.com/en/w/v524/) It is odd that the body of 'bw_write_raw_reversed' function is fully equivalent to the body of 'bw_write_raw' function. read.c 1393
- [V1003](https://www.viva64.com/en/w/v1003/) The macro 'BON_COMPRESS_' is a dangerous expression. The parameters 'count', 'n' must be surrounded by parentheses. private.h 75
- [V1003](https://www.viva64.com/en/w/v1003/) The macro 'BON_COMPRESS_' is a dangerous expression. The parameter 'n' must be surrounded by parentheses. private.h 77
- [V1003 ](https://www.viva64.com/en/w/v1003/)The macro 'BON_ALLOC_TYPE' is a dangerous expression. The parameter 'n' must be surrounded by parentheses. private.h 301
- [V1003 ](https://www.viva64.com/en/w/v1003/)The macro 'BON_CALLOC_TYPE' is a dangerous expression. The parameter 'n' must be surrounded by parentheses. private.h 302
- [V773 ](https://www.viva64.com/en/w/v773/)The function was exited without releasing the 'data' pointer. A memory leak is possible. bon.c 45
- [V773 ](https://www.viva64.com/en/w/v773/)The function was exited without releasing the 'fp' handle. A resource leak is possible. bon.c 45
- [V796 ](https://www.viva64.com/en/w/v796/)It is possible that 'break' statement is missing in switch statement. bon.c 161
- [V796 ](https://www.viva64.com/en/w/v796/)It is possible that 'break' statement is missing in switch statement. bon.c 308
- [V576 ](https://www.viva64.com/en/w/v796/)Incorrect format. Consider checking the fourth actual argument of the 'snprintf' function. The integer argument of 32-bit size is expected. read.c 1099

There are actually more warnings were found but they are not so interesting.